### PR TITLE
Database fix

### DIFF
--- a/db/seeds/test/favorites.js
+++ b/db/seeds/test/favorites.js
@@ -1,0 +1,26 @@
+exports.seed = function(knex, Promise) {
+  return knex('song_playlists').del()
+    .then(() => knex('favorites').del())
+    .then(() => knex('playlists').del())
+    .then(() => {
+      return Promise.all([
+        knex('favorites').insert({
+          name: 'Happy Birthday', artist_name: 'Becca and Claire', genre: 'Pop', song_rating: 100
+        }, 'id')
+        .then(favorite1 => {
+          return knex('playlists').insert({
+            playlist_name: 'Birthday Songs'
+          }, 'id')
+        .then(playlist1 => {
+          return knex('song_playlists').insert({
+            favorite_id: favorite1[0],
+            playlist_id: playlist1[0]
+          })
+        })
+        })
+        .then(() => console.log('Seeding complete!'))
+        .catch(error => console.log(`Error seeding data: ${error}`))
+      ])
+    })
+    .catch(error => console.log(`Error seeding data: ${error}`));
+};

--- a/knexfile.js
+++ b/knexfile.js
@@ -2,6 +2,19 @@
 
 module.exports = {
 
+  test: {
+    client: 'pg',
+    connection: 'postgres://localhost/playbackend',
+    migrations: {
+      directory: './db/migrations'
+    },
+    seeds: {
+      directory: './db/seeds/test'
+    },
+    useNullAsDefault: true
+  },
+
+
   development: {
     client: 'pg',
     connection:  'postgres://localhost/playbackend',

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -1,10 +1,11 @@
+process.env.NODE_ENV = "test";
+
 const chai = require('chai');
 const should = chai.should();
 const chaiHttp = require('chai-http');
 const server = require('../server');
 
-const environment = process.env.NODE_ENV || 'development';
-const configuration = require('../knexfile')[environment];
+const configuration = require('../knexfile')["test"];
 const database = require('knex')(configuration);
 
 pry = require('pryjs')
@@ -17,7 +18,6 @@ describe("My API routes", () => {
     .then(() => {
       database.migrate.latest()
       .then(() => {
-
         database.seed.run()
         .then( () => done())
         .catch(error => {
@@ -51,9 +51,9 @@ describe("My API routes", () => {
 
   describe("GET /api/v1/favorites/:id", () => {
     it("should return a favorite by id", done => {
+      eval(pry.it)
       chai.request(server)
       .get("/api/v1/favorites/1")
-      eval(pry.it)
       .end((err, response) => {
         response.should.have.status(200);
         response.should.be.json;
@@ -71,7 +71,7 @@ describe("My API routes", () => {
         response.body[0].song_rating.should.equal('100');
         done();
       });
-    }).timeout(10000000000)
+    }).timeout(1000000000000000000)
   });
 
   describe("GET /api/v1/playlists", () => {

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -51,7 +51,6 @@ describe("My API routes", () => {
 
   describe("GET /api/v1/favorites/:id", () => {
     it("should return a favorite by id", done => {
-      eval(pry.it)
       chai.request(server)
       .get("/api/v1/favorites/1")
       .end((err, response) => {
@@ -92,10 +91,8 @@ describe("My API routes", () => {
 
   describe("GET /api/v1/playlists/:id", () => {
     it("should return one playlist by id", done => {
-      database('playlists').select('*').then(data => resolve(data))
-      function resolve(playlist) {
         chai.request(server)
-        .get(`/api/v1/playlists/${playlist[0].id}`)
+        .get(`/api/v1/playlists/1`)
         .end((err, response) => {
           response.should.have.status(200);
           response.should.be.json;

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -103,7 +103,6 @@ describe("My API routes", () => {
           response.body[0].playlist_name.should.equal('Birthday Songs');
           done();
         });
-      };
     });
   });
 

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -7,25 +7,25 @@ const environment = process.env.NODE_ENV || 'development';
 const configuration = require('../knexfile')[environment];
 const database = require('knex')(configuration);
 
+pry = require('pryjs')
+
 chai.use(chaiHttp);
 
 describe("My API routes", () => {
-  before((done) => {
-    database.migrate.latest()
-    .then( () => done())
-    .catch(error => {
-      throw error;
-    });
-  });
-
   beforeEach((done) => {
-    database.seed.run()
-    .then( () => done())
-    .catch(error => {
-      throw error;
+    database.migrate.rollback()
+    .then(() => {
+      database.migrate.latest()
+      .then(() => {
+
+        database.seed.run()
+        .then( () => done())
+        .catch(error => {
+          throw error;
+        });
+      });
     });
   });
-
 
   describe("GET /api/v1/favorites", () => {
     it("should return all of the favorites", done => {
@@ -51,28 +51,27 @@ describe("My API routes", () => {
 
   describe("GET /api/v1/favorites/:id", () => {
     it("should return a favorite by id", done => {
-      database('favorites').select('*').then(data => resolve(data))
-      function resolve(favorite) {
-        chai.request(server)
-        .get(`/api/v1/favorites/${favorite[0].id}`)
-        .end((err, response) => {
-          response.should.have.status(200);
-          response.should.be.json;
-          response.body.should.be.a('array');
-          response.body.length.should.equal(1);
-          response.body[0].should.have.property('id');
-          response.body[0].should.have.property('name');
-          response.body[0].should.have.property('artist_name');
-          response.body[0].should.have.property('genre');
-          response.body[0].should.have.property('song_rating');
-          response.body[0].name.should.equal('Happy Birthday');
-          response.body[0].artist_name.should.equal('Becca and Claire');
-          response.body[0].genre.should.equal('Pop');
-          response.body[0].song_rating.should.equal('100');
-          done();
-        });
-      };
-    });
+      chai.request(server)
+      .get("/api/v1/favorites/1")
+      eval(pry.it)
+      .end((err, response) => {
+        response.should.have.status(200);
+        response.should.be.json;
+        response.body.should.be.a('array');
+        response.body.length.should.equal(1);
+        response.body[0].should.have.property('id');
+        response.body[0].should.have.property('name');
+        response.body[0].should.have.property('artist_name');
+        response.body[0].should.have.property('genre');
+        response.body[0].should.have.property('song_rating');
+        response.body[0].id.should.equal(1);
+        response.body[0].name.should.equal('Happy Birthday');
+        response.body[0].artist_name.should.equal('Becca and Claire');
+        response.body[0].genre.should.equal('Pop');
+        response.body[0].song_rating.should.equal('100');
+        done();
+      });
+    }).timeout(10000000000)
   });
 
   describe("GET /api/v1/playlists", () => {


### PR DESCRIPTION
@corywest Thank you for taking a look!
## Direction for Reviewer: The beforeEach spec block is not truncating all database primary keys back to zero. Some front-end students assured me this was possible X-) I tried this with the existing knexfile setup we built in class, and also tried adding a test environment, which is currently present. We would like to implement this so we can test for something like GET /api/v1/playlist/1 <--- inputting the seed id.
<img width="705" alt="screen shot 2018-12-08 at 4 41 32 pm" src="https://user-images.githubusercontent.com/39714935/49691820-22fb3a00-fb08-11e8-8d69-7c4a02b23b9a.png">
I do not think there is a problem with the block syntax, please let me know if you notice something in the config / environment setup that is preventing the migrate.rollback / preventing the GET BY ID tests from passing.
